### PR TITLE
melhorando performance

### DIFF
--- a/src/services/cache/index.js
+++ b/src/services/cache/index.js
@@ -1,8 +1,13 @@
 import NodeCache from "node-cache";
 import { generateImage } from "../counterPanelCreator/index.js";
 
+let oldCacheSize = 0
 export const cache = new NodeCache({deleteOnExpire: false})
 
 cache.addListener('addingAddress', () => {
-  generateImage(cache.stats.keys)
+  if(cache.stats.keys !== oldCacheSize){
+    generateImage(cache.stats.keys)
+    oldCacheSize = cache.stats.keys
+    return
+  }
 })


### PR DESCRIPTION
Realmente, gerar a imagem toda vez que o suário recarrega a página(mesmo o valor não mudando) é péssimo! A seguir tem dois prints com o resultado dessa pequena mudança.

![without cache verification](https://user-images.githubusercontent.com/68869379/190704752-6fdf8c0c-0e80-4d07-801d-ac91c6cef85e.png)
| Péssimo, caro, capenga

![with cache verification](https://user-images.githubusercontent.com/68869379/190704846-c31c91a1-c2d6-441d-93f7-7bebb923a567.png)
| Bonito, estável, barato